### PR TITLE
#36 Category display aligned and does not overlay

### DIFF
--- a/dist/main.css
+++ b/dist/main.css
@@ -51,6 +51,7 @@ body {
     min-width: 3px;
     border-radius: 4px 4px 0 0;
     overflow: hidden;
+    cursor: pointer;
 }
 #x-axis{
     width: 100%;
@@ -106,3 +107,11 @@ body {
 .scale-labelPercentage {
     right: -25px;
 }
+.scale-labelX {
+    width: 100%;
+    text-align: center;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    padding-bottom: 20px;
+} 

--- a/static/main.css
+++ b/static/main.css
@@ -51,6 +51,7 @@ body {
     min-width: 3px;
     border-radius: 4px 4px 0 0;
     overflow: hidden;
+    cursor: pointer;
 }
 #x-axis{
     width: 100%;
@@ -106,3 +107,11 @@ body {
 .scale-labelPercentage {
     right: -25px;
 }
+.scale-labelX {
+    width: 100%;
+    text-align: center;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    padding-bottom: 20px;
+} 


### PR DESCRIPTION
 #36  Overlay for Category Display Name fixed
  
Category Display Name was making issue with overlay if categories are increased or if the width of the screen is decreased which is fixed.
