### PR TITLE
Adjust ticks

### DIFF
--- a/src/axis.ts
+++ b/src/axis.ts
@@ -1,22 +1,25 @@
 import * as d3 from "d3";
 import { Pareto} from "./pareto";
+import { Settings } from "./settings";
 
- export function renderAxes(pareto: Pareto) {
+ export function renderAxes(pareto: Pareto, settings: Settings) {
     d3.selectAll("path").remove();
     d3.selectAll("g").remove();
 
     const paretoCategoryValues:string[] = moduleCategories(pareto)
 
-    let ticks=moduleTicks(pareto)
     var d3svg = d3.select("svg");
     const svg:any = document.querySelector("#svg");
     const svgBoundingClientRect:any = svg.getBoundingClientRect();
+    let ticks=moduleTicks( svgBoundingClientRect.height, settings.style.label.size)
+
 
     var d3svg = d3.select("svg");
     const categoryAxis= moduleCategoryAxis(paretoCategoryValues, 0, svgBoundingClientRect.width);
     const valueAxis = moduleValueAxis(pareto.maxValue,svgBoundingClientRect.height,ticks);
     const percentageAxis =  modulePercentageAxis(svgBoundingClientRect.height)
-   
+    const valueScaleTickNumber = svgBoundingClientRect.height / (settings.style.label.size * 2 + 6);
+
     var g = d3svg
         .append("g") 
         .attr("transform", "translate(" + 65 + "," + 0 + ")");
@@ -67,15 +70,26 @@ const moduleCategories = (pareto: Pareto)=>{
     });
     return paretoCategoryValues;
 }
-const moduleTicks = (pareto: Pareto)=>{
-    let ticks:number = 0;
-    if(pareto.maxValue <= 50){
+
+/**
+ * Calculates ticks
+ * @param pareto 
+ * @param height
+ * @param labelSize The size of the label font
+ * @returns Tick number 
+ */
+const moduleTicks = (height: number, labelSize: number) =>{
+
+    let ticks = height / (labelSize * 2 + 6);
+
+    if(height <= 500){
         ticks = 5;
-    }else if (pareto.maxValue >50 && pareto.maxValue <= 100){
-        ticks= 10;
-    }else {
-        ticks= 20;
+    } else if (height > 500 && height < 1000 ){
+        ticks = 10;
+    } else {
+        ticks = 20;
     }
+
     return ticks;
 }
 export {moduleCategoryAxis,modulePercentageAxis,moduleValueAxis, moduleTicks,moduleCategories};

--- a/src/axis.ts
+++ b/src/axis.ts
@@ -1,95 +1,85 @@
 import * as d3 from "d3";
-import { Pareto} from "./pareto";
+import { Pareto } from "./pareto";
 import { Settings } from "./settings";
 
- export function renderAxes(pareto: Pareto, settings: Settings) {
+export function renderAxes(pareto: Pareto, settings: Settings) {
     d3.selectAll("path").remove();
     d3.selectAll("g").remove();
 
-    const paretoCategoryValues:string[] = moduleCategories(pareto)
+    const paretoCategoryValues: string[] = moduleCategories(pareto);
 
     var d3svg = d3.select("svg");
-    const svg:any = document.querySelector("#svg");
-    const svgBoundingClientRect:any = svg.getBoundingClientRect();
-    let ticks=moduleTicks( svgBoundingClientRect.height, settings.style.label.size)
-
+    const svg: any = document.querySelector("#svg");
+    const svgBoundingClientRect: any = svg.getBoundingClientRect();
+    let ticks = moduleTicks(svgBoundingClientRect.height, settings.style.label.size);
 
     var d3svg = d3.select("svg");
-    const categoryAxis= moduleCategoryAxis(paretoCategoryValues, 0, svgBoundingClientRect.width);
-    const valueAxis = moduleValueAxis(pareto.maxValue,svgBoundingClientRect.height,ticks);
-    const percentageAxis =  modulePercentageAxis(svgBoundingClientRect.height)
-    const valueScaleTickNumber = svgBoundingClientRect.height / (settings.style.label.size * 2 + 6);
+    const categoryAxis = moduleCategoryAxis(paretoCategoryValues, 0, svgBoundingClientRect.width);
+    const valueAxis = moduleValueAxis(pareto.maxValue, svgBoundingClientRect.height, ticks);
+    const percentageAxis = modulePercentageAxis(svgBoundingClientRect.height);
 
-    var g = d3svg
-        .append("g") 
-        .attr("transform", "translate(" + 65 + "," + 0 + ")");
-  
+    var g = d3svg.append("g").attr("transform", "translate(" + 65 + "," + 0 + ")");
+
     g.append("g")
         .attr("transform", "translate(0," + (svgBoundingClientRect.height - 50) + ")")
-        .call(d3.axisBottom(categoryAxis).scale(categoryAxis))
-        
+        .call(d3.axisBottom(categoryAxis).scale(categoryAxis));
 
     g.append("g").call(d3.axisLeft(valueAxis).ticks(ticks));
     g.append("g")
         .attr("transform", "translate(" + (svgBoundingClientRect.width - 100) + " ,0)")
-        .call(d3.axisRight(percentageAxis).tickPadding(2).ticks(10)
-        .tickFormat(function(d) {
-          return d + "%";
-        }));
+        .call(
+            d3
+                .axisRight(percentageAxis)
+                .tickPadding(2)
+                .ticks(10)
+                .tickFormat(function (d) {
+                    return d + "%";
+                })
+        );
 }
 
-const moduleCategoryAxis =(domain:any, rangeStart:number , rangeWidth:number)=>{
-
+const moduleCategoryAxis = (domain: any, rangeStart: number, rangeWidth: number) => {
     let categoryAxis = d3
-            .scaleBand()
-            .domain(domain)           
-            .range([rangeStart, rangeWidth - 100])
-            .paddingInner(0.13)
-            .paddingOuter(0.26)
+        .scaleBand()
+        .domain(domain)
+        .range([rangeStart, rangeWidth - 100])
+        .paddingInner(0.13)
+        .paddingOuter(0.26);
     return categoryAxis;
-
-}
-const moduleValueAxis = (domain:any,rangeHeight:number,ticks:number)=>{
+};
+const moduleValueAxis = (domain: any, rangeHeight: number, ticks: number) => {
     let valueAxis = d3
-            .scaleLinear()
-            .domain([0, domain]).nice(ticks)
-            .range([rangeHeight - 50, 100])
-        return valueAxis;
-}
-const modulePercentageAxis = (rangeHeight: number)=>{
-   let percentageAxis = d3
-    .scaleLinear()
-    .domain([0 , 100 ])
-    .range([rangeHeight - 50, 100]);
+        .scaleLinear()
+        .domain([0, domain])
+        .nice(ticks)
+        .range([rangeHeight - 50, 100]);
+    return valueAxis;
+};
+const modulePercentageAxis = (rangeHeight: number) => {
+    let percentageAxis = d3
+        .scaleLinear()
+        .domain([0, 100])
+        .range([rangeHeight - 50, 100]);
     return percentageAxis;
-}
-const moduleCategories = (pareto: Pareto)=>{
-    const paretoCategoryValues:string[] = [];
+};
+const moduleCategories = (pareto: Pareto) => {
+    const paretoCategoryValues: string[] = [];
     pareto.stackedBars.forEach((p) => {
         paretoCategoryValues.push(p.label);
     });
     return paretoCategoryValues;
-}
+};
 
 /**
- * Calculates ticks
- * @param pareto 
+ * Calculates ticks based on height and font
+ * @param pareto
  * @param height
  * @param labelSize The size of the label font
- * @returns Tick number 
+ * @returns Tick number
  */
-const moduleTicks = (height: number, labelSize: number) =>{
-
+const moduleTicks = (height: number, labelSize: number) => {
     let ticks = height / (labelSize * 2 + 6);
 
-    if(height <= 500){
-        ticks = 5;
-    } else if (height > 500 && height < 1000 ){
-        ticks = 10;
-    } else {
-        ticks = 20;
-    }
-
     return ticks;
-}
-export {moduleCategoryAxis,modulePercentageAxis,moduleValueAxis, moduleTicks,moduleCategories};
+};
+export { moduleCategoryAxis, modulePercentageAxis, moduleValueAxis, moduleTicks, moduleCategories };

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,7 +117,7 @@ window.Spotfire.initialize(async (mod) => {
         //to do: render Pareto
         //when renderPareto method has been implemented it should be invoked here
 
-        renderPareto(pareto, {} as Settings);
+        renderPareto(pareto, settings);
 
 
         //for testing purposes

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -22,8 +22,8 @@ import {Settings, renderSettings} from "./Settings"
 
 export function renderPareto(pareto: Pareto, settings: Settings) {
     
-    renderAxes(pareto)
-    renderStackedBars(pareto);
+    renderAxes(pareto, settings)
+    renderStackedBars(pareto, settings);
     renderCumulativeLine(pareto);
     //renderSettings(settings);
 }

--- a/src/stackedBars.ts
+++ b/src/stackedBars.ts
@@ -12,9 +12,9 @@ import{moduleCategoryAxis,moduleValueAxis, moduleTicks,moduleCategories} from ".
 
     const svg:any = document.querySelector("#svg");
     const svgBoundingClientRect:any = svg.getBoundingClientRect();
-    let ticks=moduleTicks(svgBoundingClientRect.height, settings.style.label.size);
+    const ticks=moduleTicks(svgBoundingClientRect.height, settings.style.label.size);
     const categoryAxis= moduleCategoryAxis(paretoCategoryValues, 0, svgBoundingClientRect.width);
-    const valueAxis = moduleValueAxis(pareto.maxValue,svgBoundingClientRect.height,ticks);
+    const valueAxis = moduleValueAxis(pareto.maxValue, svgBoundingClientRect.height, ticks);
 
     var d3svg = d3.select("svg");
     let g =d3svg.select("g")

--- a/src/stackedBars.ts
+++ b/src/stackedBars.ts
@@ -1,20 +1,21 @@
 import * as d3 from "d3";
 import {Pareto} from "./pareto";
+import { Settings } from "./settings";
 import{moduleCategoryAxis,moduleValueAxis, moduleTicks,moduleCategories} from "./axis"
 /**
  * Render the bars using d3
  * @param pareto Pareto data structure
  */
- export function renderStackedBars(pareto: Pareto) {
+ export function renderStackedBars(pareto: Pareto, settings: Settings) {
    
     const paretoCategoryValues:string[] = moduleCategories(pareto)
 
-    let ticks=moduleTicks(pareto)
     const svg:any = document.querySelector("#svg");
     const svgBoundingClientRect:any = svg.getBoundingClientRect();
+    let ticks=moduleTicks(svgBoundingClientRect.height, settings.style.label.size);
     const categoryAxis= moduleCategoryAxis(paretoCategoryValues, 0, svgBoundingClientRect.width);
     const valueAxis = moduleValueAxis(pareto.maxValue,svgBoundingClientRect.height,ticks);
-   
+
     var d3svg = d3.select("svg");
     let g =d3svg.select("g")
 


### PR DESCRIPTION
## #110 Base number of ticks on pixel height instead of the  displayed data

Instead of basing the number of ticks on the data being visualised it is now calculated based on the height and font size of the labels. 

![image](https://user-images.githubusercontent.com/63287104/203521968-b851c538-825f-49f2-828f-b96da242ad41.png)

closes #110 