### PR TITLE
#111 Use index for identifying stacked bar data

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ window.Spotfire.initialize(async (mod) => {
                 let barValue = row.continuous(valueAxisName).value<number>() || 0;
                 totalValue += barValue;
                 let barLabel = hasColorExpression ? row.categorical(colorAxisName).formattedValue() : leaf.formattedValue();;
-                let barIndex = hasColorExpression ? row.categorical(colorAxisName).leafIndex : leaf.leafIndex;
+                let barIndex = leaf.leafIndex;
                 return {
                     color: row.color().hexCode,
                     value: barValue,


### PR DESCRIPTION
Use leafIndex for identifying x position

- Get leafIndex from the Spotfire API to use instead of label
- Add variables to the interfaces
- Add function to get an array of indices
