### PR TITLE
Revert "Revert "#111 Use index for identifying stacked bar data""

### DIFF
--- a/src/axis.ts
+++ b/src/axis.ts
@@ -67,6 +67,13 @@ const moduleCategories = (pareto: Pareto)=>{
     });
     return paretoCategoryValues;
 }
+const moduleIndices = (pareto: Pareto)=>{
+    const paretoCategoryIndices:number[] = [];
+    pareto.stackedBars.forEach((p) => {
+        paretoCategoryIndices.push(p.index);
+    });
+    return paretoCategoryIndices;
+}
 const moduleTicks = (pareto: Pareto)=>{
     let ticks:number = 0;
     if(pareto.maxValue <= 50){
@@ -78,4 +85,4 @@ const moduleTicks = (pareto: Pareto)=>{
     }
     return ticks;
 }
-export {moduleCategoryAxis,modulePercentageAxis,moduleValueAxis, moduleTicks,moduleCategories};
+export {moduleCategoryAxis,modulePercentageAxis,moduleValueAxis, moduleTicks,moduleCategories, moduleIndices};

--- a/src/cumulativeLine.ts
+++ b/src/cumulativeLine.ts
@@ -1,6 +1,6 @@
 import * as d3 from "d3";
 import {Pareto} from "./pareto";
-import{moduleCategoryAxis, moduleCategories, modulePercentageAxis} from "./axis"
+import{moduleCategoryAxis, moduleIndices, modulePercentageAxis} from "./axis"
 
 /**
  * Render the cumulative line using d3
@@ -8,17 +8,17 @@ import{moduleCategoryAxis, moduleCategories, modulePercentageAxis} from "./axis"
  */
 export function renderCumulativeLine(pareto: Pareto) {
 
-    const paretoCategoryValues:string[] = moduleCategories(pareto)
+    const paretoCategoryIndices:number[] = moduleIndices(pareto)
 
     let d3svg = d3.select("svg")
     const svg:any = document.querySelector("#svg");
     const svgBoundingClientRect:any = svg.getBoundingClientRect();
-    const categoryAxisBandwidth = moduleCategoryAxis(paretoCategoryValues, 0, svgBoundingClientRect.width); //used to get bandwidth later
-    const categoryAxis = moduleCategoryAxis(paretoCategoryValues, categoryAxisBandwidth.bandwidth()/2, svgBoundingClientRect.width + (categoryAxisBandwidth.bandwidth()/2));
+    const categoryAxisBandwidth = moduleCategoryAxis(paretoCategoryIndices, 0, svgBoundingClientRect.width); //used to get bandwidth later
+    const categoryAxis = moduleCategoryAxis(paretoCategoryIndices, categoryAxisBandwidth.bandwidth()/2, svgBoundingClientRect.width + (categoryAxisBandwidth.bandwidth()/2));
     const valueAxis = modulePercentageAxis(svgBoundingClientRect.height);
 
     const positions = pareto.stackedBars.map((stackedBar) => {
-        return [stackedBar.label, stackedBar.cumulativePercentage];
+        return [stackedBar.index, stackedBar.cumulativePercentage];
     })
 
     var line = d3.line<any>()

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,16 +43,19 @@ window.Spotfire.initialize(async (mod) => {
                 let barValue = row.continuous(valueAxisName).value<number>() || 0;
                 totalValue += barValue;
                 let barLabel = hasColorExpression ? row.categorical(colorAxisName).formattedValue() : leaf.formattedValue();;
+                let barIndex = hasColorExpression ? row.categorical(colorAxisName).leafIndex : leaf.leafIndex;
                 return {
                     color: row.color().hexCode,
                     value: barValue,
-                    label: barLabel
+                    label: barLabel,
+                    index: barIndex
                 } as Bar
             })
 
             return {
                 bars: bars,
                 label: leaf.formattedPath(),
+                index: leaf.leafIndex,
                 totalValue: totalValue,
                 cumulativeValue: 0
             } as StackedBar

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ window.Spotfire.initialize(async (mod) => {
                 let barValue = row.continuous(valueAxisName).value<number>() || 0;
                 totalValue += barValue;
                 let barLabel = hasColorExpression ? row.categorical(colorAxisName).formattedValue() : leaf.formattedValue();;
-                let barIndex = hasColorExpression ? row.categorical(colorAxisName).leafIndex : leaf.leafIndex;
+                let barIndex = leaf.leafIndex;
                 return {
                     color: row.color().hexCode,
                     value: barValue,

--- a/src/pareto.ts
+++ b/src/pareto.ts
@@ -20,6 +20,7 @@ export interface StackedBar {
     bars: Bar[];
     totalValue: number;
     label: string;
+    index: number;
     cumulativeValue: number; //cumulative value in the sorted array of stacked bars
     cumulativePercentage: number
 }
@@ -27,5 +28,6 @@ export interface StackedBar {
 export interface Bar {
     value: number;
     label: string;
+    index: number;
     color: string;
 }


### PR DESCRIPTION
Because of issues with merging the stackedBarIndex branch after the revert, this is being reverted again so we can merge the changes.