### PR TITLE
#96 Fix Mod Name Typo

### DIFF
--- a/static/mod-manifest.json
+++ b/static/mod-manifest.json
@@ -1,7 +1,7 @@
 {
     "apiVersion": "1.2",
     "version": "0.1.0",
-    "name": "pareto Chart",
+    "name": "Pareto Chart",
     "id": "sfire-mods-pareto",
     "icon": "icon.svg",
     "properties": [


### PR DESCRIPTION
#96 Fix the typo in the mod name.  It is now Pareto Chart instead of pareto Chart

closes #96 