### PR TITLE
Bar spacing

### DIFF
--- a/src/axis.ts
+++ b/src/axis.ts
@@ -39,12 +39,15 @@ export function renderAxes(pareto: Pareto, settings: Settings) {
 }
 
 const moduleCategoryAxis = (domain: any, rangeStart: number, rangeWidth: number) => {
+    const padding: number = 0.18;
+
     let categoryAxis = d3
         .scaleBand()
         .domain(domain)
         .range([rangeStart, rangeWidth - 100])
-        .paddingInner(0.18)
-        .paddingOuter(0.18);
+        .paddingInner(padding)
+        .paddingOuter(padding);
+
     return categoryAxis;
 };
 const moduleValueAxis = (domain: any, rangeHeight: number, ticks: number) => {

--- a/src/axis.ts
+++ b/src/axis.ts
@@ -43,8 +43,8 @@ const moduleCategoryAxis = (domain: any, rangeStart: number, rangeWidth: number)
         .scaleBand()
         .domain(domain)
         .range([rangeStart, rangeWidth - 100])
-        .paddingInner(0.13)
-        .paddingOuter(0.26);
+        .paddingInner(0.18)
+        .paddingOuter(0.18);
     return categoryAxis;
 };
 const moduleValueAxis = (domain: any, rangeHeight: number, ticks: number) => {


### PR DESCRIPTION
# #107 Adjust the spacing between bars

Previously the inner and outerpadding had different values. Now we use the same ones instead. 

### Before
![7](https://user-images.githubusercontent.com/63287104/204251936-bab2baa1-4f95-47f7-a399-4cb85524db50.png)

### After
![image](https://user-images.githubusercontent.com/63287104/204252174-655dda18-d57c-4ff9-b13d-5a956731f064.png)

closes #107 
