### PR TITLE
#167 Prioritize the line under the markers

### DIFF
--- a/src/cumulativeLine.ts
+++ b/src/cumulativeLine.ts
@@ -35,6 +35,16 @@ export function renderCumulativeLine(pareto: Pareto) {
         .y(function (d): number {
             return valueAxis(d[1])!;
         });
+
+    d3svg
+        .append("path")
+        .datum(positions)
+        .attr("class", "line")
+        .attr("transform", "translate(" + resources.PADDINGLEFT + "," + resources.PADDINGBOTTOMDOWN + ")")
+        .attr("d", line)
+        .style("fill", "none")
+        .style("stroke", "#3050EF")
+        .style("stroke-width", lineWeight);
     d3svg
         .append("g")
         .selectAll("dot")
@@ -51,14 +61,4 @@ export function renderCumulativeLine(pareto: Pareto) {
         .attr("transform", "translate(" + resources.PADDINGLEFT + "," + resources.PADDINGBOTTOMDOWN + ")")
 
         .style("fill", "#3050EF");
-
-    d3svg
-        .append("path")
-        .datum(positions)
-        .attr("class", "line")
-        .attr("transform", "translate(" + resources.PADDINGLEFT + "," + resources.PADDINGBOTTOMDOWN + ")")
-        .attr("d", line)
-        .style("fill", "none")
-        .style("stroke", "#3050EF")
-        .style("stroke-width", lineWeight);
 }

--- a/src/cumulativeLine.ts
+++ b/src/cumulativeLine.ts
@@ -59,6 +59,5 @@ export function renderCumulativeLine(pareto: Pareto) {
         })
         .attr("r", 5)
         .attr("transform", "translate(" + resources.PADDINGLEFT + "," + resources.PADDINGBOTTOMDOWN + ")")
-
         .style("fill", "#3050EF");
 }


### PR DESCRIPTION
closes #167 

The line has been prioritized under the markers/dots. 
The correct color was fixed earlier. 

To see the prioritization I used another shade of blue (see pictures), but the dots and line are the same color in the code.

![image](https://user-images.githubusercontent.com/63287192/207085095-27ad956e-35be-46f6-b8d9-c0cfbe25eed8.png)
![image](https://user-images.githubusercontent.com/63287192/207085134-22b02384-7158-43ca-b634-34f44394cd05.png)
