### PR TITLE
#177 Cumulative line markers

### DIFF
--- a/src/cumulativeLine.ts
+++ b/src/cumulativeLine.ts
@@ -106,7 +106,9 @@ export function renderCumulativeLine(pareto: Pareto, settings: Settings) {
             .attr("transform", "translate(" + resources.PADDINGLEFT + "," + resources.PADDINGBOTTOMDOWN + ")")
             .style("fill", stroke)
             .on("click", function (event: any, d: any) {
-                d.mark(event);
+                pareto.stackedBars.forEach((stackedBar) => {
+                    if (stackedBar.cumulativePercentage <= d.cumulativePercentage) stackedBar.mark(event);
+                });
             })
             .on("mouseover", function (event: any, d: any) {
                 showLineToolTip(d);


### PR DESCRIPTION
closes #177

When clicking on a line marker all the stackedbars up to that marker are selected. 
It does not work the same way with rectangular selection.

![image](https://user-images.githubusercontent.com/63287192/207839222-3ebd95b8-47ed-4e67-9535-67b43de8527a.png)

