### PR TITLE
#174 implement border when hovering cutoff line

### DIFF
--- a/src/cumulativeLine.ts
+++ b/src/cumulativeLine.ts
@@ -132,7 +132,7 @@ export function renderCumulativeLine(pareto: Pareto, settings: Settings) {
             .attr("cx", baseDot.cx.baseVal.value)
             .attr("cy", baseDot.cy.baseVal.value)
             .attr("transform", "translate(" + resources.PADDINGLEFT + "," + resources.PADDINGBOTTOMDOWN + ")")
-            .attr("stroke", "#000")
+            .attr("stroke", settings.style.onMouseOverBox.stroke)
             .attr("stroke-width", settings.style.onMouseOverBox.strokeWidth)
             .attr("fill-opacity", 0)
             .attr("r", 7);

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,7 +80,11 @@ window.Spotfire.initialize(async (mod) => {
                     weight: context.styling.scales.line.stroke
                 },
                 marking: { color: context.styling.scales.font.color },
-                onMouseOverBox: { strokeWidth: 0.5, padding: 3, stroke: "#000" },
+                onMouseOverBox: {
+                    strokeWidth: 0.5,
+                    padding: 3,
+                    stroke: context.styling.general.backgroundColor !== "#2A2A2A" ? "#000" : "#FFFF"
+                },
                 selectionBox: { strokeWidth: 0.5 },
                 inbarsSeparatorWidth: 1.5
             }

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,7 +80,7 @@ window.Spotfire.initialize(async (mod) => {
                     weight: context.styling.scales.line.stroke
                 },
                 marking: { color: context.styling.scales.font.color },
-                onMouseOverBox: { strokeWidth: 0.5, padding: 3 },
+                onMouseOverBox: { strokeWidth: 0.5, padding: 3, stroke: "#000" },
                 selectionBox: { strokeWidth: 0.5 },
                 inbarsSeparatorWidth: 1.5
             }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -15,7 +15,7 @@ export interface Settings {
         //font: { size: number; weight: string; style: string; color: string; fontFamily: string };
         marking: { color: string };
         background: { color: string };
-        onMouseOverBox: { strokeWidth: number; padding: number };
+        onMouseOverBox: { strokeWidth: number; padding: number; stroke: string };
         selectionBox: { strokeWidth: number };
         inbarsSeparatorWidth: number;
     };

--- a/src/stackedBars.ts
+++ b/src/stackedBars.ts
@@ -66,16 +66,19 @@ export function renderStackedBars(pareto: Pareto, settings: Settings) {
         .style("stroke", "#FA7864")
         .style("stroke-width", resources.LINEWEIGHT)
         .style("stroke-dasharray", "8 8 ")
-        .attr("x1", range)
+        .attr("x1", range - 3)
         .attr("y1", percentageAxis(80))
-        .attr("x2", 0)
+        .attr("x2", 0 + 2)
         .attr("y2", percentageAxis(80))
         .on("click", selectedBars)
-        .on("mouseover", showLineToolTip)
+        .on("mouseover", function () {
+            showLineToolTip();
+            drawHoverLine();
+        })
         .on("mouseout", function () {
+            d3.selectAll(".hover-line").remove();
             settings.tooltip.hide();
         });
-
     // Add invisible line to click on
     sel.append("line")
         .style("stroke", "transparent")
@@ -85,10 +88,30 @@ export function renderStackedBars(pareto: Pareto, settings: Settings) {
         .attr("x2", 0)
         .attr("y2", percentageAxis(80))
         .on("click", selectedBars)
-        .on("mouseover", showLineToolTip)
+        .on("mouseover", function () {
+            showLineToolTip();
+            drawHoverLine();
+        })
         .on("mouseout", function () {
+            d3.selectAll(".hover-line").remove();
             settings.tooltip.hide();
         });
+
+    function drawHoverLine() {
+        sel.append("rect")
+            .classed("hover-line", true)
+            .attr("stroke", settings.style.onMouseOverBox.stroke)
+            .attr("stroke-width", settings.style.onMouseOverBox.strokeWidth)
+            .attr("shape-rendering", "crispEdges")
+            .attr("rx", "3")
+            .attr("fill", "none")
+            .attr("x", 0)
+            .attr("y", percentageAxis(80) - 3)
+            .attr("height", resources.LINEWEIGHT + 3)
+            .attr("width", range);
+    }
+
+    //cutoff.append("path").datum(hoverLine).style("stroke", "black");
     //add an a
     inBars
         .on("click", function (event: any, d: any) {
@@ -119,7 +142,7 @@ export function renderStackedBars(pareto: Pareto, settings: Settings) {
             .attr("x", bBox.x - padding)
             .attr("height", bBox.height + 2 * padding)
             .attr("width", bBox.width + 2 * padding)
-            .attr("stroke", "#000")
+            .attr("stroke", settings.style.onMouseOverBox.stroke)
             .attr("stroke-width", settings.style.onMouseOverBox.strokeWidth)
             .attr("shape-rendering", "crispEdges")
             .attr("fill", "none");


### PR DESCRIPTION
#174 Mouse over cutoff line border

Add hovering effect around 80/20 cutoff line

![image](https://user-images.githubusercontent.com/63287104/207892260-14749c2f-d4f7-4457-b940-2427a655ace5.png)

![image](https://user-images.githubusercontent.com/63287104/207900226-4f5be5ee-9b1e-4719-acc8-f0df52a2ad4c.png)

closes #174 #178 
